### PR TITLE
feat: zustand 초기 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "@tanstack/react-query-devtools": "^5.17.9",
     "axios": "^1.6.5",
     "framer-motion": "^10.17.12",
+    "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",
     "styled-components": "^6.1.8",
-    "styled-reset": "^4.5.2"
+    "styled-reset": "^4.5.2",
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,7 +1,8 @@
-const Header = () => {
-  return (
-    <div>Header</div>
-  )
-}
+import useBoundStore from '../../store/store';
 
-export default Header
+const Header = () => {
+  const bearPopulation = useBoundStore((state) => state.bears);
+  return <div>Header d{bearPopulation}</div>;
+};
+
+export default Header;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { createBearSlice, createFishSlice } from './testSlice';
+import { createJSONStorage, devtools, persist } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+
+const persisitKeys = ['bears'];
+
+const persistOption = {
+  name: 'food-storage', // name of the item in the storage (must be unique)
+  storage: createJSONStorage(() => sessionStorage), // (optional) by default, 'localStorage' is used
+  partialize: (state) =>
+    Object.fromEntries(
+      Object.entries(state).filter(([key]) => persisitKeys.includes(key))
+    ),
+};
+
+const useBoundStore = create(
+  // immer로 불변성 보장
+  immer(
+    devtools(
+      persist(
+        (...a) => ({
+          ...createBearSlice(...a),
+          ...createFishSlice(...a),
+        }),
+        persistOption
+      )
+    )
+  )
+);
+
+//
+
+export default useBoundStore;

--- a/src/store/testSlice.js
+++ b/src/store/testSlice.js
@@ -1,0 +1,10 @@
+export const createFishSlice = (set) => ({
+  fishes: 0,
+  addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
+});
+
+export const createBearSlice = (set) => ({
+  bears: 0,
+  addBear: () => set((state) => ({ bears: state.bears + 1 })),
+  eatFish: () => set((state) => ({ fishes: state.fishes - 1 })),
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  server:{
-    port:3000,
+  server: {
+    port: 3000,
   },
   resolve: {
     alias: {
@@ -15,10 +15,11 @@ export default defineConfig({
       '@constants': '/src/constants',
       '@hooks': '/src/hooks',
       '@pages': '/src/pages',
-      'queries': '/src/queries',
+      '@queries': '/src/queries',
       '@router': '/src/router',
       '@styles': '/src/styles',
       '@utils': '/src/utils',
+      '@store': '/src/store',
     },
   },
-})
+});


### PR DESCRIPTION
## PR요약
Zustand 초기 store 설정입니다.


## PR내용

### 도입
클라이언트 상태관리로 Zustand를 도입했습니다. 서버 상태는 tanstack-query를 사용하기에 상대적으로 가볍고 쉽게 사용할 수 있는 Zustand를 선정했습니다. 그리고 기존에 많이 사용하던 Redux처럼 클라이언트 상태를 하나의 스토어로 관리할 수 있기에 상대적으로 러닝커브가 적을 것으로 판단했습니다.   

참고 영상 : https://youtu.be/nkXIpGjVxWU?si=3hYMZZv_aGshV6z6

### 코드 설명

#### 0. 개요
 src/store/store.js에서 useBoundStore라는 하나의 스토어를 생성합니다. 분리된 파일에서 slice를 만들고 (testSlice.js 참고) 스토어에서 하나로 묶어 줍니다. 서드파티로는 immer,devtools, persist를 사용합니다. 

#### 1. 슬라이스 패턴 
Zustand는 여러개의 스토어를 만들 수도 있지만, 하나의 스토어를 사용하면  상대적으로 관리하기도 쉽고, Redux devtools를 사용가능 해지기 때문에 디버깅에도 용이합니다. 때문에 store.js에 하나의 스토어를 만들고 그 안에 여러 슬라이스들을 묶어서 사용하는 패턴을 사용했습니다. 
링크: https://docs.pmnd.rs/zustand/guides/slices-pattern

#### 2.서드파티 
 - immer : Zustand의 store와 slice에서는 얕은 수준에서 불변성을 보장합니다. 하지만 중첩된 객체의 경우 상태 변경을 하려면 추가적으로 코드를 작성해야하는데 immer를 통해 변하는 상태만 기입하면 나머지 불변성을 보장할 수 있습니다.
 참고자료: https://www.youtube.com/watch?v=8QkXAj1s5GA
 
 - devtools: 크롬 익스텐션을 통해 기존의 redux-devtools를 사용할 수 있습니다. 
 - persist: 인증 관련 혹은 브라우저 스토리지에 저장할 필요가 있는 상태를 위한 서드파티입니다. 
 -persistOption을 통해 설정하고 partialize값을 통해 스토리지에 저장되는 상태 key값을 정합니다.


## 기타
- store alias 추가 했습니다.

####작성 파일:
![image](https://github.com/NU-WA-Project/FE/assets/118579021/2195bc3c-2a85-4086-8f18-5c23ece884d8)
