### PR TITLE
fix: 스타일드 컴포넌트 theme 구조 변경

### DIFF
--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,21 +1,22 @@
 const theme = {
-  primary: {
-    100: '#E2E3FE',
-    200: '#B6B7FD',
-    300: '#888BFC',
-    400: '#575DFB',
-    500: '#1026F2',
-    600: '#06149A',
-    700: '#010548',
+  color: {
+    primary100: '#E2E3FE',
+    primary200: '#B6B7FD',
+    primary300: '#888BFC',
+    primary400: '#575DFB',
+    primary500: '#1026F2',
+    primary600: '#06149A',
+    primary700: '#010548',
+    grey100: '#F1F1F1',
+    grey200: '#D6D6D6',
+    grey300: '#AFAFAF',
+    grey400: '#898989',
+    grey500: '#656565',
+    grey600: '#434343',
+    grey700: '#242424',
   },
-  grey: {
-    100: '#F1F1F1',
-    200: '#D6D6D6',
-    300: '#AFAFAF',
-    400: '#898989',
-    500: '#656565',
-    600: '#434343',
-    700: '#242424',
+  shadow: {
+    primary: '10px 12px 33px 0px rgba(102, 102, 102, 0.10)',
   },
 };
 


### PR DESCRIPTION
## Motivation🤔 
(코드 작성 내용, 의도를 설명해주세요)

theme의 색상을 초기에는 중첩된 객체로 만들었는데 사용하다보니 중첩으로 접근하기가 상당히 번거롭다고 느껴서 
theme의 구조를 변경했습니다.



## Key Changes 🔑 
(주요 변화를 기입해주세요. 디렉토리 구조/ ui변경 이미지 첨부 등)
### before
![image](https://github.com/NU-WA-Project/FE/assets/118579021/3ed564b2-f13d-4353-9ffa-c09e4861708e)
### after
![image](https://github.com/NU-WA-Project/FE/assets/118579021/27b64822-59d7-4dff-a0f4-8e81bc5818e2)


color안에 primary와 grey스케일을 집어 넣었습니다.



## To Reviewrs 🙏 
(그 외 리뷰어에게 전달 하고 싶은 말을 적어주세요.)

### 사용 예시
![image](https://github.com/NU-WA-Project/FE/assets/118579021/3d1bc049-5cad-488e-9160-996785d7f076)

