### PR TITLE
design:chakra ui theme 설정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,14 +7,15 @@ import Header from '@components/Header/Header';
 import Footer from '@components/Footer/Footer';
 import SideBar from '@components/SideBar/SideBar';
 import GlobalStyle from '@styles/globalStyle';
-import theme from './styles/theme';
+import theme from '@styles/theme';
+import chakraTheme from '@styles/chakraTheme';
 
 const queryClient = new QueryClient();
 function App() {
   return (
     <>
       <ThemeProvider theme={theme}>
-        <ChakraProvider>
+        <ChakraProvider theme={chakraTheme}>
           <GlobalStyle />
           <Header />
           <SideBar />

--- a/src/components/Button/NormalButton.jsx
+++ b/src/components/Button/NormalButton.jsx
@@ -1,0 +1,7 @@
+import { Button as ChButton } from '@chakra-ui/react';
+
+const NormalButton = ({ children, ...restProps }) => {
+  return <ChButton {...restProps}>{children}</ChButton>;
+};
+
+export default NormalButton;

--- a/src/pages/login/LoginPage.jsx
+++ b/src/pages/login/LoginPage.jsx
@@ -1,7 +1,0 @@
-const LoginPage = () => {
-  return (
-    <div>LoginPage</div>
-  )
-}
-
-export default LoginPage

--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -1,0 +1,16 @@
+import NormalButton from '../../components/Button/NormalButton';
+import { Button } from '@chakra-ui/react';
+const LoginPage = () => {
+  return (
+    <div>
+      <NormalButton borderRadius={'full'} colorScheme="secondary">
+        테스트
+      </NormalButton>
+      <Button borderRadius={'full'} colorScheme="teal">
+        테스트
+      </Button>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -2,7 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import App from '../App';
 import NotFoundPage from '../pages/not_found/NotFoundPage';
 import MainPage from '../pages/main/MainPage';
-import LoginPage from '../pages/login/LoginPage';
+import LoginPage from '../pages/login/index';
 import SignupPage from '../pages/signup/SignupPage';
 import SelectPlan from '../pages/selectPlan';
 export const Router = createBrowserRouter([

--- a/src/styles/chakraTheme.js
+++ b/src/styles/chakraTheme.js
@@ -1,0 +1,38 @@
+import { extendTheme } from '@chakra-ui/react';
+
+const chakraTheme = extendTheme({
+  colors: {
+    primary: {
+      100: '#E2E3FE',
+      200: '#B6B7FD',
+      300: '#888BFC',
+      400: '#575DFB',
+      500: '#1026F2',
+      600: '#06149A',
+      700: '#010548',
+    },
+    secondary: {
+      50: '#E2E1FA',
+      100: '#C4C2F7',
+      200: '#A6A4F4',
+      300: '#8886F1',
+      400: '#6A68EE',
+      500: '#575DFB',
+      600: '#4F52F2',
+      700: '#4548EA',
+      800: '#3D3DE2',
+      900: '#2F2EB8',
+    },
+    grey: {
+      100: '#F1F1F1',
+      200: '#D6D6D6',
+      300: '#AFAFAF',
+      400: '#898989',
+      500: '#656565',
+      600: '#434343',
+      700: '#242424',
+    },
+  },
+});
+
+export default chakraTheme;


### PR DESCRIPTION
## Motivation🤔 
(코드 작성 내용, 의도를 설명해주세요)
#9 이슈 

- 차크라 ui의  theme설정
- 버튼 재활용에 대한 의견

## Key Changes 🔑 
(주요 변화를 기입해주세요. 디렉토리 구조/ ui변경 이미지 첨부 등)

- chakra ui에 기존 피그마의 컬러 팔레트를 설정
- primary, grey는 피그마 변수 참조
- secondary는 primaray의 base color 기준으로 우선 새로운 팔레트 (10개) gpt로 생성
- 해당 컬레 팔레트 명으로 chakra ui의 colorScheme을 사용할 수 있음 
- ex)
 ```jsx
<NormalButton borderRadius={'full'} colorScheme="secondary">
        테스트
      </NormalButton>
```
- 차크라 버튼을 가져다가 래핑해서 다시 써보려고 했는데 결과적으로 별로 좋지 않음.
- 속성 자동완성이 지원이 안되어서 속성을 일일이 찾아봐야함.

### 결론 : 차크라 버튼 그냥 쓰고, 차크라에서 지원안되는 추가 기능이 필요할 때 재사용을 만드는게 좋을 것 같습니다.




## To Reviewrs 🙏 
(그 외 리뷰어에게 전달 하고 싶은 말을 적어주세요.)
